### PR TITLE
Scale undershoot to overshoot ratio by 1/10.

### DIFF
--- a/hrf_opt/config_default.csv
+++ b/hrf_opt/config_default.csv
@@ -48,11 +48,13 @@ varUndDspMax = 2.2
 # Step size for peak and undershoot dispersion of the hrf function:
 varDspStp = 0.3
 
-# Minimum peak to undershoot ratio:
-varPkUndRatMin = 1.5
+# Minimum peak to undershoot ratio (will be scaled by 1/10):
+# 1 means that undershoot is 1/10 of overshoot
+varPkUndRatMin = 1.0
 
-# Maximum peak to undershoot ratio:
-varPkUndRatMax = 10.5
+# Maximum peak to undershoot ratio (will be scaled by 1/10):
+# 10 means that undershoot is equal to overshoot
+varPkUndRatMax = 10.0
 
 # Step size for the peak to undershoot ratio
 varPkUndRatStp = 1.0

--- a/hrf_opt/hrf_opt_utils.py
+++ b/hrf_opt/hrf_opt_utils.py
@@ -69,8 +69,9 @@ def crt_hrf_prm(varPkDelMin, varPkDelMax, varUndDelMin, varUndDelMax,
 
     # Define vector for weighting of undershoot relative to peak,
     # e.g. 6 means 1:6 weighting
-    vecPkUndRat = np.arange(varPkUndRatMin, varPkUndRatMax+varPkUndRatStp,
-                            varPkUndRatStp)
+    vecPkUndRat = np.divide(10, np.arange(varPkUndRatMin,
+                                          varPkUndRatMax+varPkUndRatStp,
+                                          varPkUndRatStp))
 
     # Find combinations of all parameters
     # Exclude combinations where undershoot delay less than peak delay


### PR DESCRIPTION
- This inversion allows testing more grid points in the range where the undershoot is of equal magnitude as overshoot.